### PR TITLE
Startup telemetry

### DIFF
--- a/hardware_interface/include/eps.h
+++ b/hardware_interface/include/eps.h
@@ -119,9 +119,11 @@ typedef enum eps_mode eps_mode_e;
 SAT_returnState eps_refresh_instantaneous_telemetry();
 SAT_returnState eps_refresh_startup_telemetry();
 eps_instantaneous_telemetry_t get_eps_instantaneous_telemetry();
-void EPS_getHK(eps_instantaneous_telemetry_t *telembuf);
+eps_startup_telemetry_t get_eps_startup_telemetry();
+void EPS_getHK(eps_instantaneous_telemetry_t *telembuf, eps_startup_telemetry_t *telem_startup_buf);
 eps_mode_e get_eps_batt_mode();
 void prv_instantaneous_telemetry_letoh(eps_instantaneous_telemetry_t *telembuf);
+void prv_startup_telemetry_letoh(eps_startup_telemetry_t *telem_startup_buf);
 // If changing the two functions below, update system tasks, too.
 uint8_t eps_get_pwr_chnl(uint8_t pwr_chnl_port);
 int8_t eps_set_pwr_chnl(uint8_t pwr_chnl_port, bool status);

--- a/hardware_interface/include/eps.h
+++ b/hardware_interface/include/eps.h
@@ -58,7 +58,7 @@ typedef struct __attribute__((packed)) {
 
 struct __attribute__((packed)) eps_instantaneous_telemetry {
     uint8_t cmd;         // value 0
-    int8_t status;       // 0 –on success
+    int8_t status;       // 0 ï¿½on success
     double timestampInS; // with ms precision
     uint32_t uptimeInS;
     uint32_t bootCnt;          // system startup count
@@ -80,22 +80,44 @@ struct __attribute__((packed)) eps_instantaneous_telemetry {
     uint16_t outputOnDelta[18];  // seconds
     uint16_t outputOffDelta[18]; // seconds
     uint8_t outputFaultCnt[18];
-    int8_t temp[14];       // 1-4 –MPPT converter temp, 5-8 –output converter temp, 9 –on-board battery temp, 10–12
-                           // –external battery pack temp, 13-14 -output expander temp
-    uint8_t battMode;      // 0 –critical, 1 –safe, 2 –normal, 3 –full
-    uint8_t mpptMode;      // 0 –HW, 1 –manual, 2 –auto, 3 –auto with timeout
-    uint8_t batHeaterMode; // 0 –manual, 1 –auto
-    uint8_t batHeaterState;   // 0 –off, 1 –on
+    int8_t temp[14];       // 1-4 ï¿½MPPT converter temp, 5-8 ï¿½output converter temp, 9 ï¿½on-board battery temp, 10ï¿½12
+                           // ï¿½external battery pack temp, 13-14 -output expander temp
+    uint8_t battMode;      // 0 ï¿½critical, 1 ï¿½safe, 2 ï¿½normal, 3 ï¿½full
+    uint8_t mpptMode;      // 0 ï¿½HW, 1 ï¿½manual, 2 ï¿½auto, 3 ï¿½auto with timeout
+    uint8_t batHeaterMode; // 0 ï¿½manual, 1 ï¿½auto
+    uint8_t batHeaterState;   // 0 ï¿½off, 1 ï¿½on
     uint16_t PingWdt_toggles; // Total number of power channel toggles caused by failed ping watchdog
     uint8_t PingWdt_turnOffs; // Total number of power channel offs caused by failed ping watchdog
+};
+
+struct __attribute__((packed)) eps_startup_telemetry {
+    uint8_t cmd;         // value 1
+    double timestamp; // with ms precision
+    uint32_t last_reset_reason_reg; //Last reset reason register value, see below
+    uint32_t bootCnt;          // total system boot count
+    uint8_t FallbackConfigUsed = 0;
+    uint8_t rtcInit = 0;
+    uint8_t rtcClkSourceLSE = 0;
+    uint8_t flashAppInit = 0;
+    int8_t Fram4kPartitionInit = 0;
+    int8_t Fram520kPartitionInit = 0;
+    int8_t intFlashPartitionInit = 0;
+    int8_t FSInit = 0;
+    int8_t FTInit = 0;
+    int8_t supervisorInit = 0;
+    uint8_t uart1App = 0;
+    uint8_t uart2App = 0;
+    int8_t tmp107Init = 0;
 };
 
 enum eps_mode { critical = 0, safe = 1, normal = 2, full = 3 };
 
 typedef struct eps_instantaneous_telemetry eps_instantaneous_telemetry_t;
+typedef struct eps_startup_telemetry eps_startup_telemetry_t;
 typedef enum eps_mode eps_mode_e;
 
 SAT_returnState eps_refresh_instantaneous_telemetry();
+SAT_returnState eps_refresh_startup_telemetry();
 eps_instantaneous_telemetry_t get_eps_instantaneous_telemetry();
 void EPS_getHK(eps_instantaneous_telemetry_t *telembuf);
 eps_mode_e get_eps_batt_mode();

--- a/hardware_interface/source/eps.c
+++ b/hardware_interface/source/eps.c
@@ -62,6 +62,19 @@ SAT_returnState eps_refresh_instantaneous_telemetry() {
     return SATR_OK;
 }
 
+SAT_returnState eps_refresh_startup_telemetry() {
+    uint8_t cmd = 1; // ' subservice' command defined in ICD Section 24.2.2
+    eps_startup_telemetry_t telem_startup_buf;
+    
+    csp_transaction_w_opts(CSP_PRIO_LOW, EPS_APP_ID, EPS_INSTANTANEOUS_TELEMETRY, 10000, &cmd, sizeof(cmd),
+                           &telem_startup_buf, sizeof(eps_startup_telemetry_t), CSP_0_CRC32);
+    // data is little endian, must convert to host order
+    // refer to the NanoAvionics datasheet for details
+    prv_instantaneous_telemetry_letoh(&telem_startup_buf);
+    prv_set_instantaneous_telemetry(telem_startup_buf);
+    return SATR_OK;
+}
+
 eps_instantaneous_telemetry_t get_eps_instantaneous_telemetry() {
     eps_instantaneous_telemetry_t telembuf;
     eps_t *eps;


### PR DESCRIPTION
Create startup telemetry in order to retrieve eps' last reset reason.